### PR TITLE
use standard; fix undefined var: arg

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -4,21 +4,22 @@ var simplify = require('./')
 var fs = require('fs')
 var argv = require('minimist')(process.argv.slice(2))
 var concat = require('concat-stream')
+var stdin
 
 var tolerance = argv.t || argv.tolerance || 0.001
 tolerance = +tolerance // cast to Number
 
-if (!process.stdin.isTTY || arg === '-') {
-  var stdin = process.stdin
+if (!process.stdin.isTTY || argv._[0] === '-') {
+  stdin = process.stdin
 } else {
-  var stdin = fs.createReadStream(argv._[0])
+  stdin = fs.createReadStream(argv._[0])
 }
 
 // buffer all input TODO streaming simplification
-stdin.pipe(concat(function(buffer) {
+stdin.pipe(concat(function (buffer) {
   try {
     var geojson = JSON.parse(buffer)
-  } catch(e) {
+  } catch (e) {
     return console.error(e)
   }
   var result = simplify(geojson, tolerance)

--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
 var simplify = require('simplify-geometry')
 
-module.exports = function(geojson, tolerance, dontClone) {
+module.exports = function (geojson, tolerance, dontClone) {
   if (!dontClone) geojson = JSON.parse(JSON.stringify(geojson)) // clone obj
   if (geojson.features) return simplifyFeatureCollection(geojson, tolerance)
-  else if (geojson.type && geojson.type === "Feature") return simplifyFeature(geojson, tolerance)
+  else if (geojson.type && geojson.type === 'Feature') return simplifyFeature(geojson, tolerance)
   else return new Error('FeatureCollection or individual Feature required')
 }
 
-module.exports.simplify = function(coordinates, tolerance) {
+module.exports.simplify = function (coordinates, tolerance) {
   return simplify(coordinates, tolerance)
 }
 
 // modifies in-place
-function simplifyFeature(feat, tolerance) {
+function simplifyFeature (feat, tolerance) {
   var geom = feat.geometry
   var type = geom.type
   if (type === 'LineString') {
@@ -32,7 +32,7 @@ function simplifyFeature(feat, tolerance) {
 }
 
 // modifies in-place
-function simplifyFeatureCollection(fc, tolerance) {
+function simplifyFeatureCollection (fc, tolerance) {
   // process all LineString features, skip non LineStrings
   for (var i = 0; i < fc.features.length; i++) {
     fc.features[i] = simplifyFeature(fc.features[i], tolerance)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "simplify-geojson": "./cli.js"
   },
   "scripts": {
-    "test": "node test.js"
+    "test": "standard && node test.js"
   },
   "author": "max ogden",
   "license": "BSD",
@@ -17,6 +17,7 @@
     "concat-stream": "~1.4.1"
   },
   "devDependencies": {
+    "standard": "^6.0.4",
     "tape": "~2.4.2"
   },
   "repository": {

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ var test = require('tape')
 var fs = require('fs')
 var simplify = require('./')
 
-test('FeatureCollection w/ a LineString in it', function(t) {
+test('FeatureCollection w/ a LineString in it', function (t) {
   var fcLine = JSON.parse(fs.readFileSync('./test-data/oakland-route.geojson'))
   var len = fcLine.features[0].geometry.coordinates.length
   var simplified = simplify(fcLine, 0.001)
@@ -11,7 +11,7 @@ test('FeatureCollection w/ a LineString in it', function(t) {
   t.end()
 })
 
-test('FeatureCollection w/ a MultiPolygon in it', function(t) {
+test('FeatureCollection w/ a MultiPolygon in it', function (t) {
   var fsMp = JSON.parse(fs.readFileSync('./test-data/alaska.geojson'))
   var len = JSON.stringify(fsMp, null, '  ').split('\n').length
   var simplified = simplify(fsMp, 0.5)


### PR DESCRIPTION
I noticed `arg` is an undefined variable ([cli.js#L11](https://github.com/maxogden/simplify-geojson/compare/master...ngoldman:standardize?expand=1#diff-2cce40143051e25f811b56c79d619bf5L11)). I changed it to be `argv._[0]` as I think that's what it's supposed to be. I threw standard in there too, hope that's alright.