### PR TITLE
add cli tests, usage (-h)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -4,15 +4,24 @@ var simplify = require('./')
 var fs = require('fs')
 var argv = require('minimist')(process.argv.slice(2))
 var concat = require('concat-stream')
+var usage = fs.readFileSync('./usage.txt', { encoding: 'utf8' })
 var stdin
 
 var tolerance = argv.t || argv.tolerance || 0.001
 tolerance = +tolerance // cast to Number
 
-if (!process.stdin.isTTY || argv._[0] === '-') {
+if (argv.help || argv.h) {
+  console.log(usage)
+  process.exit()
+}
+
+if (argv._[0] && argv._[0] !== '-') {
+  stdin = fs.createReadStream(argv._[0])
+} else if (!process.stdin.isTTY || argv._[0] === '-') {
   stdin = process.stdin
 } else {
-  stdin = fs.createReadStream(argv._[0])
+  console.log(usage)
+  process.exit(1)
 }
 
 // buffer all input TODO streaming simplification

--- a/test.js
+++ b/test.js
@@ -1,5 +1,8 @@
 var test = require('tape')
 var fs = require('fs')
+var concat = require('concat-stream')
+var child_process = require('child_process')
+var spawn = child_process.spawn
 var simplify = require('./')
 
 test('FeatureCollection w/ a LineString in it', function (t) {
@@ -7,8 +10,27 @@ test('FeatureCollection w/ a LineString in it', function (t) {
   var len = fcLine.features[0].geometry.coordinates.length
   var simplified = simplify(fcLine, 0.001)
   var newLen = simplified.features[0].geometry.coordinates.length
-  t.true(newLen < len, 'should get simplified')
+  t.true(newLen < len, 'should get simplified (' + newLen + ' < ' + len + ')')
   t.end()
+})
+
+test('FeatureCollection w/ a LineString in it (cli)', function (t) {
+  t.plan(1)
+
+  var file = './test-data/oakland-route.geojson'
+  var fcLine = JSON.parse(fs.readFileSync('./test-data/oakland-route.geojson'))
+  var len = fcLine.features[0].geometry.coordinates.length
+  var proc = spawn('./cli.js', [file, '-t 0.001'])
+
+  proc.stderr.on('data', function (data) {
+    t.error(data.toString(), 'does not error')
+  })
+
+  proc.stdout.pipe(concat(function (buffer) {
+    var simplified = JSON.parse(buffer.toString())
+    var newLen = simplified.features[0].geometry.coordinates.length
+    t.true(newLen < len, 'should get simplified (' + newLen + ' < ' + len + ')')
+  }))
 })
 
 test('FeatureCollection w/ a MultiPolygon in it', function (t) {
@@ -16,8 +38,27 @@ test('FeatureCollection w/ a MultiPolygon in it', function (t) {
   var len = JSON.stringify(fsMp, null, '  ').split('\n').length
   var simplified = simplify(fsMp, 0.5)
   var newLen = JSON.stringify(simplified, null, '  ').split('\n').length
-  t.true(newLen < len, 'should get simplified')
+  t.true(newLen < len, 'should get simplified (' + newLen + ' < ' + len + ')')
   t.end()
+})
+
+test('FeatureCollection w/ a MultiPolygon in it (cli)', function (t) {
+  t.plan(1)
+
+  var file = './test-data/alaska.geojson'
+  var fsMp = JSON.parse(fs.readFileSync(file))
+  var len = JSON.stringify(fsMp, null, '  ').split('\n').length
+  var proc = spawn('./cli.js', [file, '-t 0.5'])
+
+  proc.stderr.on('data', function (data) {
+    t.error(data.toString(), 'does not error')
+  })
+
+  proc.stdout.pipe(concat(function (buffer) {
+    var geoJson = JSON.parse(buffer.toString())
+    var newLen = JSON.stringify(geoJson, null, '  ').split('\n').length
+    t.true(newLen < len, 'should get simplified (' + newLen + ' < ' + len + ')')
+  }))
 })
 
 // TODO tests for other types (send me a PR :D)

--- a/usage.txt
+++ b/usage.txt
@@ -1,0 +1,2 @@
+Usage: simplify-geojson file [options]
+    --tolerance, -t       Tolerance in degrees. 1 degree is roughly equivalent to 69 miles. (default: 0.001)


### PR DESCRIPTION
- add cli tests
- improve pipe behavior in `child_process` environments
- add usage (`--help` or `-h` option)

```
Usage: simplify-geojson file [options]
    --tolerance, -t       Tolerance in degrees. 1 degree is roughly equivalent to 69 miles. (default: 0.001)
```