### PR TITLE
Update minimist to version 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "concat-stream": "~1.4.1",
-    "minimist": "1.2.5",
+    "minimist": "1.2.6",
     "simplify-geometry": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Minimist had a prototype pollution bug that could cause privilege escalation in some circumstances when handling untrusted user input.

See [https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795](Snyk) link.

This bumps minimist version to currently recommended version: 1.2.6